### PR TITLE
Added text-overflow hidden to tile.

### DIFF
--- a/src/components/siteTile.vue
+++ b/src/components/siteTile.vue
@@ -50,6 +50,7 @@
     height: 25px;
     line-height: 25px;
     background: rgba(0,0,0,0.1);
+    overflow: hidden;
   }
 
 </style>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5770711/33844868-8154378e-de56-11e7-9b14-0e0519ab7c41.png)
I noticed the tiles need a quick fix for text-overflow hidden. When you have an emoji if you tile titles it's more obvious. Cool extension thanks!